### PR TITLE
Revert Granite Rapids AP/SP ucode back to IPU 2026.1

### DIFF
--- a/SOURCES/intel-microcode-20260416-1.xs8.noarch.rpm.tgz
+++ b/SOURCES/intel-microcode-20260416-1.xs8.noarch.rpm.tgz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6377c1e362be0199726523b639f93a1f94eb650dd8454de57b7f83cba313dea5
-size 16603035

--- a/SOURCES/intel-microcode-20260416-2.xs8.noarch.rpm.tgz
+++ b/SOURCES/intel-microcode-20260416-2.xs8.noarch.rpm.tgz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca629e737b08350949c247a7959063974ea5b216142e7653d19423cd576a6240
+size 16606225

--- a/SPECS/intel-microcode.spec
+++ b/SPECS/intel-microcode.spec
@@ -1,5 +1,5 @@
 # Citrix does not publish SRPMs for their package, so we're duplicating efforts
-%define xs_release 1
+%define xs_release 2
 %define xs_dist xs8
 
 Summary:        Intel Microcode
@@ -71,6 +71,10 @@ rm -rf %{buildroot}
 /lib/firmware/intel-ucode
 
 %changelog
+* Thu Jun 04 2026 Gael Duperrey <gduperrey@vates.tech> - 20260416-2
+- Update to Intel's microcode, based on XenServer's 20260416-2 release.
+ - Revert Granite Rapids AP/SP ucode back to IPU 2026.1 to fix a hang on boot on some platforms.
+
 * Wed May 13 2026 Philippe Coval <philippe.coval@vates.tech> - 20260416-1
 - Update to Intel's publicly released microcode-20260512, based on XenServer's 20260416 release that has the same contents.
 - Security updates for INTEL-SA-01420


### PR DESCRIPTION
Revert Granite Rapids AP/SP ucode back to IPU 2026.1 to fix a hang on boot on some platforms.

### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3372

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

We are synchronizing with the update released by XenServer which includes the following change: Revert Granite Rapids AP/SP ucode back to IPU 2026.1 to fix a hang on boot on some platforms.

#### Release Target

- [X] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

8.3-next

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

Revert Granite Rapids AP/SP ucode back to IPU 2026.1 to fix a hang on boot on some platforms.

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

N/A

#### Documentation update needed

- [ ] Yes
- [X] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

<!-- Add links to the documentation update PRs if/when they are created. -->

N/A.

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Manual installation of the update in a nested server and validation of its installation and the reboot of the nested server.

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

The RPM will be installed on the CI servers and CI will run with the RPM installed.

A diff was performed between the RPM file from XenServer and the one we generated with Koji.
The only differences are the two files we kept from the XenServer file.

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

None

#### What tests have been or will be added to CI for this change? If none, explain why.

None

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [X] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
